### PR TITLE
Removed parameter `solver.reconstruction_order` from all three Maxwell examples…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,68 @@
 emclaw
 ======
 
-Solvers for Maxwell's electrodynamic equations with time-space varying coefficients based on [PyClaw]([https://alals](http://www.clawpack.org/pyclaw/index.html))
+Solvers for Maxwell's electrodynamic equations with time-space varying coefficients based on
+[PyClaw]([https://alals](http://www.clawpack.org/pyclaw/index.html))
 
-# Requierements/Dependencies
-- Python (>= 3.7), including recent releases of numpy and scipy 
-- [Clawpack](http://www.clawpack.org) (>= 5.7)
-- [PETSc](https://gitlab.com/petsc/petsc) and [PETSc4py](https://gitlab.com/petsc/petsc4py)
-- ParaView, YT, or Avizo to visualize 3D data (experimental)
+## Setup
 
-# quick _setup_
-
-1. clone the repository
-2. compile the Riemann sources
-   ```
-   export EMCLAW_PATH=path_to_emclaw_clone
-   cd $EMCLAW_PATH\emclaw\riemann
-   python setup.py build_ext -i
-   ```
-3. Add emclaw to an environment as a development module (e.g. `emclaw_env`)
-   ```
-    conda develop -n emclaw_env $EMCLAW_PATH
-    ```
-4. Test
-    ```
-    conda activate emclaw_env
-    python -c "import emclaw; print(emclaw.__path__[0])"
-    >> EMCLAW_PATH
-    ```
-
-# Documentation
-[Read the docs](https://emclaw.readthedocs.io/en/latest/)
-
-# Questions/Contact
-damian.sanroman@kaust.edu.sa
+**Tested with Ubuntu 22.10, Python 3.9.**
 
 
+### Clone this repository to your home directory
+
+    git clone https://github.com/shredEngineer/emclaw.git /home/$USER/emclaw
+
+### Create Anaconda environment
+
+You need to have [Anaconda](https://docs.anaconda.com/anaconda/install/) installed. 
+
+    conda create -n py39 python=3.9
+
+### Install dependencies
+
+
+    sudo apt install gfortran libblas-dev liblapack-dev
+	conda install -c conda-forge numpy scipy matplotlib petsc4py clawpack
+
+### Build and setup the `emclaw` package
+
+	export EMCLAW_PATH=/home/$USER/emclaw
+	cd $EMCLAW_PATH/emclaw/riemann
+
+	conda activate py39
+	python setup.py build_ext -i
+	conda develop -n py39 $EMCLAW_PATH
+
+### Quick Test 
+
+	python -c "import emclaw; print(emclaw.__path__[0])"
+
+## Examples
+
+Run the Maxwell 2D example:
+
+	cd /home/$USER/emclaw/examples/maxwell_vc_2d
+	python maxwell_2d.py
+
+The console output should look like this:
+
+	averaging
+	2022-12-30 10:27:00,924 INFO CLAW: Solution 0 computed for time t=0.000000
+	2022-12-30 10:27:01,734 INFO CLAW: Solution 1 computed for time t=10.000000
+	2022-12-30 10:27:02,526 INFO CLAW: Solution 2 computed for time t=20.000000
+	2022-12-30 10:27:03,304 INFO CLAW: Solution 3 computed for time t=30.000000
+	2022-12-30 10:27:04,080 INFO CLAW: Solution 4 computed for time t=40.000000
+	2022-12-30 10:27:04,855 INFO CLAW: Solution 5 computed for time t=50.000000
+	2022-12-30 10:27:05,636 INFO CLAW: Solution 6 computed for time t=60.000000
+	2022-12-30 10:27:06,413 INFO CLAW: Solution 7 computed for time t=70.000000
+	2022-12-30 10:27:07,193 INFO CLAW: Solution 8 computed for time t=80.000000
+	2022-12-30 10:27:07,974 INFO CLAW: Solution 9 computed for time t=90.000000
+	2022-12-30 10:27:08,750 INFO CLAW: Solution 10 computed for time t=100.000000
+
+This should have generated a new subfolder named `_output` where the results are stored.
+
+**TODO:** Generate plots.
+
+## Support
+[damian.sanroman@kaust.edu.sa](mailto:damian.sanroman@kaust.edu.sa)

--- a/examples/maxwell_vc_1d/maxwell_1d.py
+++ b/examples/maxwell_vc_1d/maxwell_1d.py
@@ -1,5 +1,3 @@
-import sys
-import os
 import numpy as np
 from emclaw.utils.materials import Material1D
 from emclaw.utils.sources import Source1D
@@ -15,7 +13,7 @@ source.setup()
 x_lower = 0.
 x_upper = 100.
 
-def em1D(mx = 1024, num_frames = 10, use_petsc = True, reconstruction_order = 5, lim_type = 2,  cfl = 1.0, conservative = True,
+def em1D(mx = 1024, num_frames = 10, use_petsc = True, cfl = 1.0, conservative = True,
          chi3 = 0.0, chi2 = 0.0, nl = False, psi = True, em = True, before_step = False,
          debug = False, outdir = './_output', output_style = 1):
 
@@ -50,7 +48,6 @@ def em1D(mx = 1024, num_frames = 10, use_petsc = True, reconstruction_order = 5,
     solver=pyclaw.SharpClawSolver1D()
     solver.num_waves  = num_waves
     solver.num_eqn    = num_eqn
-    solver.reconstruction_order = 5
     solver.lim_type = 2
 
     solver.dt_variable = True
@@ -134,6 +131,5 @@ def em1D(mx = 1024, num_frames = 10, use_petsc = True, reconstruction_order = 5,
     return claw
 
 if __name__=="__main__":
-    import sys
     from clawpack.pyclaw.util import run_app_from_main
     output = run_app_from_main(em1D)

--- a/examples/maxwell_vc_2d/maxwell_2d.py
+++ b/examples/maxwell_vc_2d/maxwell_2d.py
@@ -1,6 +1,3 @@
-import sys
-import os
-import numpy as np
 from emclaw.utils.materials import Material2D
 from emclaw.utils.sources import Source2D
 from emclaw.utils import basics
@@ -18,7 +15,7 @@ material = Material2D(shape='homogeneous',metal=False)
 material.setup()
 material._calculate_n()
 
-def em2D(mx=128,my=128,num_frames=10,cfl=1.0,outdir='./_output',use_petsc=True, before_step=False,debug=False,heading='x',shape='off',nl=False,psi=True,conservative=True):
+def em2D(mx=128,my=128,num_frames=10,cfl=1.0,outdir='./_output', before_step=False,debug=False,heading='x',shape='off',nl=False,psi=True,conservative=True):
     import clawpack.petclaw as pyclaw
     import petsc4py.PETSc as MPI
 
@@ -61,7 +58,6 @@ def em2D(mx=128,my=128,num_frames=10,cfl=1.0,outdir='./_output',use_petsc=True, 
     solver = pyclaw.SharpClawSolver2D()
     solver.num_waves  = num_waves
     solver.num_eqn    = num_eqn
-    solver.reconstruction_order = 5
     solver.lim_type = 2
 
     solver.dt_variable = True
@@ -152,6 +148,5 @@ def em2D(mx=128,my=128,num_frames=10,cfl=1.0,outdir='./_output',use_petsc=True, 
     return claw
 
 if __name__=="__main__":
-    import sys
     from clawpack.pyclaw.util import run_app_from_main
     output = run_app_from_main(em2D)

--- a/examples/maxwell_vc_3d/maxwell_3d.py
+++ b/examples/maxwell_vc_3d/maxwell_3d.py
@@ -1,5 +1,3 @@
-import sys
-import os
 import numpy as np
 from emclaw.utils.materials import Material3D
 from emclaw.utils.sources import Source3D
@@ -33,7 +31,7 @@ source.setup()
 source.transversal_offset = [sy/2.0,sz/2.0]
 source.transversal_width  = [sy/2.0,sz/2.0]
 
-def em3D(mx=64, my=64, mz=64, num_frames=10, cfl=1.0, outdir='./_output', use_petsc=True, before_step=False, debug=False, nl=False, psi=True):
+def em3D(mx=64, my=64, mz=64, num_frames=10, cfl=1.0, outdir='./_output', before_step=False, debug=False, nl=False, psi=True):
     import clawpack.petclaw as pyclaw
     import petsc4py.PETSc as MPI
 
@@ -58,7 +56,6 @@ def em3D(mx=64, my=64, mz=64, num_frames=10, cfl=1.0, outdir='./_output', use_pe
     solver = pyclaw.SharpClawSolver3D()
     solver.num_waves  = num_waves
     solver.num_eqn    = num_eqn
-    solver.reconstruction_order = 5
     solver.lim_type = 2
 
     solver.dt_variable = True
@@ -135,6 +132,5 @@ def em3D(mx=64, my=64, mz=64, num_frames=10, cfl=1.0, outdir='./_output', use_pe
     return claw
 
 if __name__=="__main__":
-    import sys
     from clawpack.pyclaw.util import run_app_from_main
     output = run_app_from_main(em3D)


### PR DESCRIPTION
…this parameter does not seem to exist anymore. Couldn't find any further info on this.

Updated README.md with complete and straightforward installation instructions.